### PR TITLE
Add getChunkFile

### DIFF
--- a/src/Save/ChunkSave.php
+++ b/src/Save/ChunkSave.php
@@ -126,6 +126,16 @@ class ChunkSave extends AbstractSave
 
         return parent::getFile();
     }
+    
+    /**
+     * Returns always the uploaded chunk file
+     *
+     * @return null|UploadedFile
+     */
+    public function getChunkFile()
+    {
+        return parent::getFile();
+    }
 
     /**
      * Appends the new uploaded data to the final file


### PR DESCRIPTION
Get always the chunk file back.

We use this plugin for uploading from a frontend to an api server. The api server merge the chunks to one file.