### PR TITLE
Set scheduler to run every hour on the 25th minute

### DIFF
--- a/config/chunk-upload.php
+++ b/config/chunk-upload.php
@@ -18,7 +18,7 @@ return [
         "timestamp" => "-3 HOURS",
         "schedule" => [
             "enabled" => true,
-            "cron" => "0 */1 * * * *" // run every hour
+            "cron" => "25 * * * *" // run every hour on the 25th minute
         ]
     ],
     "chunk" => [


### PR DESCRIPTION
Fixes ‘InvalidArgumentException  : 5 is not a valid position’ when doing ‘artisan schedule:run’