### PR TITLE
simple-uploader first chunk number is 1

### DIFF
--- a/src/Handler/ChunksInRequestSimpleUploadHandler.php
+++ b/src/Handler/ChunksInRequestSimpleUploadHandler.php
@@ -24,4 +24,17 @@ class ChunksInRequestSimpleUploadHandler extends ChunksInRequestUploadHandler
      * @static string
      */
     const KEY_ALL_CHUNKS = 'totalChunks';
+
+    /**
+     * Returns current chunk from the request.
+     *
+     * @param Request $request
+     *
+     * @return int
+     */
+    protected function getCurrentChunkFromRequest(Request $request)
+    {
+        // the chunk is indexed from 1 (for 5 chunks: 1,2,3,4,5)
+        return intval($request->get(static::KEY_CHUNK_NUMBER));
+    }
 }


### PR DESCRIPTION
> The index of the chunk in the current upload. First chunk is 1 (no base-0 counting here).

[README.md#How do I set it up with my server?](https://github.com/simple-uploader/Uploader/blob/develop/README.md#how-do-i-set-it-up-with-my-server)