### PR TITLE
Chunk missing in upload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     "test": "./vendor/bin/phpunit"
   },
   "require": {
-    "illuminate/http": "5.1 - 5.8|^6.0",
-    "illuminate/console": "5.1 - 5.8|^6.0",
-    "illuminate/support": "5.1 - 5.8|^6.0",
-    "illuminate/filesystem": "5.1 - 5.8|^6.0"
+    "illuminate/http": "5.1 - 5.8|^6.0|^7.0",
+    "illuminate/console": "5.1 - 5.8|^6.0|^7.0",
+    "illuminate/support": "5.1 - 5.8|^6.0|^7.0",
+    "illuminate/filesystem": "5.1 - 5.8|^6.0|^7.0"
   },
   "require-dev": {
-    "laravel/laravel": "5.1 - 5.8|^6.0",
+    "laravel/laravel": "5.1 - 5.8|^6.0|^7.0",
     "phpunit/phpunit": "5.7 || 6.0 || 7.0 || 7.5 || 8.4",
     "mockery/mockery": "^1.1.0",
     "friendsofphp/php-cs-fixer": "^2.16.0",

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
   },
   "require": {
     "illuminate/http": "5.1 - 5.8|^6.0|^7.0",
+
     "illuminate/console": "5.1 - 5.8|^6.0|^7.0",
     "illuminate/support": "5.1 - 5.8|^6.0|^7.0",
     "illuminate/filesystem": "5.1 - 5.8|^6.0|^7.0"

--- a/src/Handler/ChunksInRequestUploadHandler.php
+++ b/src/Handler/ChunksInRequestUploadHandler.php
@@ -33,6 +33,13 @@ class ChunksInRequestUploadHandler extends AbstractHandler
     const KEY_ALL_CHUNKS = 'chunks';
 
     /**
+     * Key for number of all chunks.
+     *
+     * @static string
+     */
+    const KEY_TOTAL_BYTES = 'filesize';
+
+    /**
      * The current chunk progress.
      *
      * @var int
@@ -47,6 +54,19 @@ class ChunksInRequestUploadHandler extends AbstractHandler
     protected $chunksTotal = 0;
 
     /**
+     * The files total bytes.
+     *
+     * @var int
+     */
+    protected $bytesTotal = 0;
+
+    /**
+     * @var loadedSize
+     */
+ 
+    protected $loadedSize = 0;
+
+    /**
      * AbstractReceiver constructor.
      *
      * @param Request        $request
@@ -59,6 +79,7 @@ class ChunksInRequestUploadHandler extends AbstractHandler
 
         $this->currentChunk = $this->getCurrentChunkFromRequest($request);
         $this->chunksTotal = $this->getTotalChunksFromRequest($request);
+        $this->bytesTotal = $this->getTotalBytesFromRequest($request);
     }
 
     /**
@@ -110,6 +131,18 @@ class ChunksInRequestUploadHandler extends AbstractHandler
     protected function getTotalChunksFromRequest(Request $request)
     {
         return intval($request->get(static::KEY_ALL_CHUNKS));
+    }
+
+    /**
+     * Returns total bytes from the request.
+     *
+     * @param Request $request
+     *
+     * @return int
+     */
+    protected function getTotalBytesFromRequest(Request $request)
+    {
+        return intval($request->get(static::KEY_TOTAL_BYTES));
     }
 
     /**
@@ -178,6 +211,25 @@ class ChunksInRequestUploadHandler extends AbstractHandler
      */
     public function getPercentageDone()
     {
+        if ($this->loadedSize) {
+          return ceil($this->loadedSize / $this->getBytesTotal() * 100);
+        }
+
         return ceil($this->currentChunk / $this->chunksTotal * 100);
+    }
+
+    public function getBytesTotal()
+    {
+        return $this->bytesTotal;
+    }
+
+    public function getFullFileSize()
+    {
+        return $this->getBytesTotal();
+    }
+
+    public function setLoadedSize($size)
+    {
+        $this->loadedSize = $size;
     }
 }

--- a/src/Handler/ContentRangeUploadHandler.php
+++ b/src/Handler/ContentRangeUploadHandler.php
@@ -55,6 +55,12 @@ class ContentRangeUploadHandler extends AbstractHandler
     protected $bytesTotal = 0;
 
     /**
+     * @var loadedSize
+     */
+ 
+    protected $loadedSize = 0;
+
+    /**
      * AbstractReceiver constructor.
      *
      * @param Request        $request
@@ -216,7 +222,20 @@ class ContentRangeUploadHandler extends AbstractHandler
         if (0 == $this->getBytesTotal()) {
             return 0;
         }
+        if ($this->loadedSize) {
+          return ceil($this->loadedSize / $this->getBytesTotal() * 100);
+        }
 
         return ceil($this->getBytesEnd() / $this->getBytesTotal() * 100);
+    }
+
+    public function getFullFileSize()
+    {
+        return $this->getBytesTotal();
+    }
+
+    public function setLoadedSize($size)
+    {
+        $this->loadedSize = $size;
     }
 }

--- a/src/Handler/DropZoneUploadHandler.php
+++ b/src/Handler/DropZoneUploadHandler.php
@@ -73,6 +73,18 @@ class DropZoneUploadHandler extends ChunksInRequestUploadHandler
     }
 
     /**
+     * Returns total bytes from the request.
+     *
+     * @param Request $request
+     *
+     * @return int
+     */
+    protected function getTotalBytesFromRequest(Request $request)
+    {
+        return intval($request->get(self::CHUNK_FILE_SIZE_INDEX, 0));
+    }
+
+    /**
      * Checks if the current abstract handler can be used via HandlerFactory.
      *
      * @param Request $request

--- a/src/Handler/NgFileUploadHandler.php
+++ b/src/Handler/NgFileUploadHandler.php
@@ -120,4 +120,17 @@ class NgFileUploadHandler extends ChunksInRequestUploadHandler
             ceil($request->get(static::KEY_TOTAL_SIZE) / $request->get(static::KEY_CHUNK_SIZE))
         );
     }
+
+    /**
+     * Returns total bytes from the request.
+     *
+     * @param Request $request
+     *
+     * @return int
+     */
+    protected function getTotalBytesFromRequest(Request $request)
+    {
+        return intval($request->get(self::KEY_TOTAL_SIZE, 0));
+    }
+
 }

--- a/src/Handler/ResumableJSUploadHandler.php
+++ b/src/Handler/ResumableJSUploadHandler.php
@@ -14,7 +14,7 @@ class ResumableJSUploadHandler extends ChunksInRequestUploadHandler
     const CHUNK_UUID_INDEX = 'resumableIdentifier';
     const CHUNK_NUMBER_INDEX = 'resumableChunkNumber';
     const TOTAL_CHUNKS_INDEX = 'resumableTotalChunks';
-
+    const TOTAL_BYTES_INDEX = 'resumableTotalSize';
     /**
      * The Resumable file uuid for unique chunk upload session.
      *
@@ -68,6 +68,18 @@ class ResumableJSUploadHandler extends ChunksInRequestUploadHandler
     protected function getTotalChunksFromRequest(Request $request)
     {
         return $request->get(self::TOTAL_CHUNKS_INDEX);
+    }
+
+    /**
+     * Returns total bytes from the request.
+     *
+     * @param Request $request
+     *
+     * @return int
+     */
+    protected function getTotalBytesFromRequest(Request $request)
+    {
+        return intval($request->get(self::TOTAL_BYTES_INDEX, 0));
     }
 
     /**

--- a/src/Handler/SingleUploadHandler.php
+++ b/src/Handler/SingleUploadHandler.php
@@ -75,4 +75,9 @@ class SingleUploadHandler extends AbstractHandler
     {
         return 100;
     }
+
+    public function getFullFileSize()
+    {
+        return 0;
+    }
 }

--- a/src/Save/ChunkSave.php
+++ b/src/Save/ChunkSave.php
@@ -221,7 +221,6 @@ class ChunkSave extends AbstractSave
             $finalPath,
             $this->file->getClientOriginalName(),
             $this->file->getClientMimeType(),
-            filesize($finalPath),
             $this->file->getError(),
             // we must pass the true as test to force the upload file
             // to use a standard copy method, not move uploaded file

--- a/src/Save/ParallelSave.php
+++ b/src/Save/ParallelSave.php
@@ -110,9 +110,11 @@ class ParallelSave extends ChunkSave
         // Get chunk files that matches the current chunk file name, also sort the chunk
         // files.
         $finalFilePath = $this->getChunkDirectory(true).'./'.$this->handler()->createChunkFileName();
-        // Delete the file if exists
+
+        // In ParallelSave Few Chunks can be with flag isLastChunk = true
+        // If File exists then another process Merging Chunks
         if (file_exists($finalFilePath)) {
-            @unlink($finalFilePath);
+          return;
         }
 
         $fileMerger = new FileMerger($finalFilePath);


### PR DESCRIPTION
1. Instead of flag IsLastChunk added Function RecalcLastChunk that calculates number of chunks loaded, total size of file and total size of chunks loaded.
Any Chunk can be Last. It is important in ParallelChunkUpload Mode.
2. Handlers changed to provide TotalFileSize.
3. Solved Problems, if few parallel processes detects on its own that everything already loaded. We have to select one process to merge Files.