### PR TITLE
FilePond support

### DIFF
--- a/config/chunk-upload.php
+++ b/config/chunk-upload.php
@@ -9,7 +9,7 @@ return [
          * Returns the folder name of the chunks. The location is in storage/app/{folder_name}
          */
         'chunks' => 'chunks',
-        'disk' => 'local',
+        'disk' => env('CHUNK_UPLOAD_DISK', 'local'),
     ],
     'clear' => [
         /*
@@ -17,7 +17,7 @@ return [
          */
         'timestamp' => '-3 HOURS',
         'schedule' => [
-            'enabled' => true,
+            'enabled' => env('CHUNK_UPLOAD_CLEAR_CHUNKS',  true),
             'cron' => '25 * * * *', // run every hour on the 25th minute
         ],
     ],

--- a/src/Handler/AbstractHandler.php
+++ b/src/Handler/AbstractHandler.php
@@ -55,6 +55,15 @@ abstract class AbstractHandler
         return false;
     }
 
+    /**
+     * Determine what was provided for the file input, and make sure we end up with
+     * an UploadedFile instance.
+     *
+     * @param mixed $fileIndexOrFile
+     * @param Request $request
+     *
+     * @return UploadedFile
+     */
     public static function getUploadedFile($fileIndexOrFile, Request $request)
     {
         $file = is_object($fileIndexOrFile)

--- a/src/Handler/AbstractHandler.php
+++ b/src/Handler/AbstractHandler.php
@@ -55,6 +55,19 @@ abstract class AbstractHandler
         return false;
     }
 
+    public static function getUploadedFile($fileIndexOrFile, Request $request)
+    {
+        $file = is_object($fileIndexOrFile)
+            ? $fileIndexOrFile
+            : $request->file($fileIndexOrFile);
+
+        if(is_array($file) && $file[0] instanceof UploadedFile) {
+            $file = $file[0];
+        }
+
+        return $file;
+    }
+
     /**
      * Checks the current setup if session driver was booted - if not, it will generate random hash.
      *

--- a/src/Handler/FilePondUploadHandler.php
+++ b/src/Handler/FilePondUploadHandler.php
@@ -46,12 +46,12 @@ class FilePondUploadHandler extends AbstractHandler
 
         // We need to pretend like we have an UploadedFile, while skipping the normal
         // validation that verifies a file was uploaded properly.
-        return new class($path, $request->header(self::HEADER_UPLOAD_NAME)) extends UploadedFile {
-            public function isValid()
-            {
-                return true;
-            }
-        };
+        return new UploadedFile($path,
+            $request->header(self::HEADER_UPLOAD_NAME),
+            null,
+            \UPLOAD_ERR_OK,
+            true
+        );
     }
 
     /**

--- a/src/Handler/FilePondUploadHandler.php
+++ b/src/Handler/FilePondUploadHandler.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Pion\Laravel\ChunkUpload\Handler;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Pion\Laravel\ChunkUpload\Config\AbstractConfig;
+use Pion\Laravel\ChunkUpload\Save\AbstractSave;
+use Pion\Laravel\ChunkUpload\Save\ChunkSave;
+use Pion\Laravel\ChunkUpload\Storage\ChunkStorage;
+
+class FilePondUploadHandler extends AbstractHandler
+{
+    const CHUNK_UUID_INDEX = 'patch';
+
+    const HEADER_UPLOAD_LENGTH = 'Upload-Length';
+    const HEADER_UPLOAD_OFFSET = 'Upload-Offset';
+    const HEADER_UPLOAD_NAME = 'Upload-Name';
+
+    /**
+     * Checks if the current abstract handler can be used via HandlerFactory.
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    public static function canBeUsedForRequest(Request $request)
+    {
+        return $request->hasHeader(self::HEADER_UPLOAD_OFFSET);
+    }
+
+    /**
+     * FilePond uploads chunks by just putting the data right in the PATCH body.
+     * There is no UploadedFile created on the request. We have to save the payload
+     * to a temporary file and create it ourself.
+     *
+     * @param $fileIndex
+     * @param Request $request
+     *
+     * @return UploadedFile|null
+     */
+    public static function getUploadedFile($fileIndex, Request $request)
+    {
+        $path = tempnam(sys_get_temp_dir(), $fileIndex . "_");
+        file_put_contents($path, $request->getContent());
+
+        return new UploadedFile(
+            $path,
+            $request->header(self::HEADER_UPLOAD_NAME),
+            null,
+            \UPLOAD_ERR_OK,
+            true
+        );
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotalSize()
+    {
+        return $this->request->header(self::HEADER_UPLOAD_LENGTH);
+    }
+
+    /**
+     * @return int
+     */
+    public function getChunkOffset()
+    {
+        return $this->request->header(self::HEADER_UPLOAD_OFFSET);
+    }
+
+    /**
+     * @return int
+     */
+    public function getChunkSize()
+    {
+        return $this->file->getSize();
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileName()
+    {
+        return $this->request->header(self::HEADER_UPLOAD_NAME);
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileUUID()
+    {
+        return $this->request->get(self::CHUNK_UUID_INDEX);
+    }
+
+    /**
+     * Creates save instance and starts saving the uploaded file.
+     *
+     * @param ChunkStorage $chunkStorage the chunk storage
+     *
+     * @return AbstractSave
+     */
+    public function startSaving($chunkStorage)
+    {
+        return new ChunkSave($this->file, $this, $chunkStorage, $this->config);
+    }
+
+    /**
+     * Returns the chunk file name for a storing the tmp file.
+     *
+     * @return string
+     */
+    public function getChunkFileName()
+    {
+        return $this->createChunkFileName($this->getFileUUID(), $this->getChunkOffset());
+    }
+
+    /**
+     * Checks if the request has first chunk.
+     *
+     * @return bool
+     */
+    public function isFirstChunk()
+    {
+        return $this->getChunkOffset() == 0;
+    }
+
+    /**
+     * Checks if the current request has the last chunk.
+     *
+     * @return bool
+     */
+    public function isLastChunk()
+    {
+        return $this->getChunkOffset() + $this->getChunkSize() == $this->getTotalSize();
+    }
+
+    /**
+     * Checks if the current request is chunked upload.
+     *
+     * @return bool
+     */
+    public function isChunkedUpload()
+    {
+        return true;
+    }
+
+    /**
+     * Returns the percentage of the upload file.
+     *
+     * @return int
+     */
+    public function getPercentageDone()
+    {
+        return ($this->getChunkOffset() + $this->getChunkSize()) / $this->getTotalSize() * 100;
+    }
+}

--- a/src/Handler/FilePondUploadHandler.php
+++ b/src/Handler/FilePondUploadHandler.php
@@ -44,13 +44,14 @@ class FilePondUploadHandler extends AbstractHandler
         $path = tempnam(sys_get_temp_dir(), $fileIndex . "_");
         file_put_contents($path, $request->getContent());
 
-        return new UploadedFile(
-            $path,
-            $request->header(self::HEADER_UPLOAD_NAME),
-            null,
-            \UPLOAD_ERR_OK,
-            true
-        );
+        // We need to pretend like we have an UploadedFile, while skipping the normal
+        // validation that verifies a file was uploaded properly.
+        return new class($path, $request->header(self::HEADER_UPLOAD_NAME)) extends UploadedFile {
+            public function isValid()
+            {
+                return true;
+            }
+        };
     }
 
     /**

--- a/src/Handler/FilePondUploadHandler.php
+++ b/src/Handler/FilePondUploadHandler.php
@@ -113,7 +113,7 @@ class FilePondUploadHandler extends AbstractHandler
      */
     public function getChunkFileName()
     {
-        return $this->createChunkFileName($this->getFileUUID(), $this->getChunkOffset());
+        return $this->createChunkFileName($this->getFileUUID());
     }
 
     /**

--- a/src/Handler/HandlerFactory.php
+++ b/src/Handler/HandlerFactory.php
@@ -18,6 +18,7 @@ class HandlerFactory
         DropZoneUploadHandler::class,
         ChunksInRequestSimpleUploadHandler::class,
         NgFileUploadHandler::class,
+        FilePondUploadHandler::class
     ];
 
     /**

--- a/src/Receiver/FileReceiver.php
+++ b/src/Receiver/FileReceiver.php
@@ -7,6 +7,7 @@ use Illuminate\Http\UploadedFile;
 use Pion\Laravel\ChunkUpload\Config\AbstractConfig;
 use Pion\Laravel\ChunkUpload\Exceptions\UploadFailedException;
 use Pion\Laravel\ChunkUpload\Handler\AbstractHandler;
+use Pion\Laravel\ChunkUpload\Handler\HandlerFactory;
 use Pion\Laravel\ChunkUpload\Save\AbstractSave;
 use Pion\Laravel\ChunkUpload\Save\ChunkSave;
 use Pion\Laravel\ChunkUpload\Save\SingleSave;
@@ -70,6 +71,14 @@ class FileReceiver
 
             $this->handler = new $handlerClass($this->request, $this->file, $this->config);
         }
+    }
+
+    public static function factory($fileIndex, Request $request)
+    {
+        $handlerClass = HandlerFactory::classFromRequest($request);
+        $file = $handlerClass::getUploadedFile($fileIndex, $request);
+
+        return new self($file, $request, $handlerClass);
     }
 
     /**

--- a/tests/Handler/FilePondUploadHandlerTest.php
+++ b/tests/Handler/FilePondUploadHandlerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace ChunkTests\Handler;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use PHPUnit\Framework\TestCase;
+use Pion\Laravel\ChunkUpload\Config\FileConfig;
+use Pion\Laravel\ChunkUpload\Handler\DropZoneUploadHandler;
+use Pion\Laravel\ChunkUpload\Handler\FilePondUploadHandler;
+
+class FilePondUploadHandlerTest extends TestCase
+{
+    protected $file = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->file = UploadedFile::fake()->create('test');
+    }
+
+    /**
+     * Checks if canBeUsedForRequest returns false when data is missing.
+     */
+    public function testCanBeUsedForInvalidRequest()
+    {
+        $request = Request::create('test', 'POST', [], [], [], []);
+        $this->assertFalse(FilePondUploadHandler::canBeUsedForRequest($request));
+    }
+
+    /**
+     * FilePond initiates a chunked upload by sending an empty request with an 'Upload-Length'
+     * header, and just looks for a server ID as response. We don't use our handler for this.
+     */
+    public function testIsNotUsedForInitialRequest()
+    {
+        $request = Request::create('test', 'POST', [], [], [], [
+            'HTTP_UPLOAD_LENGTH' => 500
+        ]);
+
+        $this->assertFalse(FilePondUploadHandler::canBeUsedForRequest($request));
+    }
+
+    public function testCanBeUsedOnValidRequest()
+    {
+        $request = Request::create('test', 'PATCH', [], [], [], [
+            'HTTP_UPLOAD_LENGTH' => 500,
+            'HTTP_UPLOAD_OFFSET' => 0,
+            'HTTP_UPLOAD_NAME'   => 'test.pdf'
+        ]);
+
+        $this->assertTrue(FilePondUploadHandler::canBeUsedForRequest($request));
+    }
+
+    public function testValidChunkRequest()
+    {
+        $request = Request::create('test', 'PATCH', [], [], [], [
+            'HTTP_UPLOAD_LENGTH' => 500,
+            'HTTP_UPLOAD_OFFSET' => 0,
+            'HTTP_UPLOAD_NAME'   => 'test.pdf'
+        ]);
+
+        $handler = new FilePondUploadHandler($request, $this->file, new FileConfig());
+
+        $this->assertTrue($handler->isFirstChunk());
+        $this->assertEquals(0, $handler->getPercentageDone());
+        $this->assertFalse($handler->isLastChunk());
+    }
+}


### PR DESCRIPTION
This PR introduces support for [FilePond](https://pqina.nl/filepond). It is fast becoming one of the more popular upload libraries, we use it heavily in a number of apps.

I have tried to build this with minimal impact on the existing core package, however there were a couple changes that I should walk through.

## Only used for chunked uploads

If a file is smaller than the FilePond configured chunk size, it is uploaded simply in one single POST. FilePond does not include any special headers or parameters. Simple uploads from FilePond then get handled by the `SingleUploadHandler`, and only chunked uploads end up using this new handler.

## Chunk data is raw request content

The `FileReceiver` assumes that if you pass in a file index, it can pull the file from the Request. 

FilePond does not submit chunks as regular file uploads, rather it puts the data in the raw request payload. Someone has to pull that data, store it on disk somewhere, and create a fake `UploadedFile` for `FileReceiver` to handle.

This means my controller code was looking like this:

```php
$path = tempnam(sys_get_temp_dir(), "upload");
file_put_contents($path, $request->getContent());

$file = new UploadedFile($path,
            $request->header(self::HEADER_UPLOAD_NAME),
            null,
            \UPLOAD_ERR_OK,
            true
);

$receiver = new FileReceiver($file, $request, HandlerFactory::classFromRequest($request));
```

Eww. I don't like that at all. 😠 

So I introduced a [new factory method to `FileReceiver`](https://github.com/pionl/laravel-chunk-upload/blob/9a6cb9c191/src/Receiver/FileReceiver.php#L76-L82) that asks the handler class instead to prepare the file. This way a handler like FilePond can do what it knows needs to be done.

The base `AbstractHandler` has a new static [`getUploadedFile`](https://github.com/pionl/laravel-chunk-upload/blob/9a6cb9c191b7e7418f95ca2f28379eef0e47987f/src/Handler/AbstractHandler.php#L67-L78) method that just mimics what `FileReceiver` what already doing with $fileIndexOrFile`, providing full backwards compatibility. Now any handler with weird/custom file preparation steps, like FilePond, can handle it directly.

Now my controller code is:

```php
$receiver = FileReceiver::factory('file', $request);
```

Yay. 😍 

The factory method gets the handler class, has the handler prepare the file, and then instantiates the `FileReceiver` as expected.

I'll be eager to hear your feedback on this approach. If you don't like it, one alternative would be for me to create a custom `FilePondReceiver` that extends `FileReceiver` and can handle the custom FilePond work that way. I wanted to first though try to stick with your existing core classes if possible.

## File index is array

If I name a FilePond instance something like `attachment` and then add multiple files, it creates hidden input form fields like this:

```html
<fieldset class="filepond--data">
    <input type="hidden" name="attachment" value="9d64faec-d734-4b7c-97e8-010ed197de75">
    <input type="hidden" name="attachment" value="8481bb89-95a5-44bf-b0ef-5c83efc79c1a">
    <input type="hidden" name="attachment" value="573b144d-066c-4104-97ae-9b25914a728d">
    <input type="hidden" name="attachment" value="c10679bb-9d90-4f73-867d-03b982e21bd9">
</fieldset>
```

Notice the issue? When the form is submitted, those will overwrite each other, and the server will only get one `$request->input('attachment')` value.

The answer is to name the FilePond instance with array syntax like `attachment[]`. This works great, however it means that each uploaded file (or chunk) is array wrapped as well. You'll see that the `AbstractHandler::getUploadedFile` method that I mentioned above also [checks to see if the file is an array](https://github.com/pionl/laravel-chunk-upload/blob/9a6cb9c191/src/Handler/AbstractHandler.php#L73-L75), and unwraps it if so. The file is always the first array element.

## ENV in config file

One other change I made was to introduce a couple ENV variables in your config file. It seems to be a good practice for Laravel packages to allow ENV to control primary configs, without the need to publish the config file and edit directly. In my case for example, I will need to specify a different `disk` depending on my environment (local, qa, production). 

The fallback values are what you had before, so this is fully backwards compatible.

## Full example

My working controller code is now this:

```php
public function upload(Request $request) {
        $receiver = FileReceiver::factory('file', $request);
        
        if (!$receiver->isUploaded()) {
              // A chunked upload is being initiated. Just send back a unique ID.
              return response(Str::uuid())->header('Content-Type', 'text/plain');
        }
        
        $save = $receiver->receive();
        
        if ($save->isFinished()) {
            // Handle the save...
            return $this->saveFile($save->getFile());
        }
        
        // We are in chunk mode. Note that FilePond doesn't _need_ any progress
        // or response, this would just be for debugging client-side if needed.
        
        return response()->json([
            "done" => $save->handler()->getPercentageDone(),
            'status' => true
        ]);
}
```

The only real differences here compared to the example repo are the 1) FileReceiver factory method, and 2) returning a unique ID (instead of throwing an exception) if no file or payload was sent.

Look forward to feedback!