### PR TITLE
L9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,12 @@
     "test": "./vendor/bin/phpunit"
   },
   "require": {
-    "illuminate/http": "5.2 - 5.8 | ^6.0 | ^7.0 | ^8.0",
-    "illuminate/console": "5.2 - 5.8 | ^6.0 | ^7.0 | ^8.0",
-    "illuminate/support": "5.2 - 5.8 | ^6.0 | ^7.0 | ^8.0",
-    "illuminate/filesystem": "5.2 - 5.8 | ^6.0 | ^7.0 | ^8.0"
+    "illuminate/http": "5.2 - 5.8 | ^6.0 | ^7.0 | ^8.0 | ^9.0",
+    "illuminate/console": "5.2 - 5.8 | ^6.0 | ^7.0 | ^8.0 | ^9.0",
+    "illuminate/support": "5.2 - 5.8 | ^6.0 | ^7.0 | ^8.0 | ^9.0",
+    "illuminate/filesystem": "5.2 - 5.8 | ^6.0 | ^7.0 | ^8.0 | ^9.0"
   },
   "require-dev": {
-    "laravel/laravel": "5.2 - 5.8 | ^6.0 | ^7.0 | ^8.0",
     "phpunit/phpunit": "5.7 | 6.0 | 7.0 | 7.5 | 8.4 | ^8.5 | ^9.3",
     "mockery/mockery": "^1.1.0 | ^1.3.0",
     "friendsofphp/php-cs-fixer": "^2.16.0",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pion/laravel-chunk-upload",
+  "name": "drjdr/laravel-chunk-upload",
   "description": "Service for chunked upload with several js providers",
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
Hi,

this is just a PR as POC for the adjustments for L9.
My setup uses only PHP 8.1 and L9, so I didnt remove the old releases.
Given the recent changes in Flysystem v3 I would do the following:
- Make the update only available for L ^9.0
- Tag this as a 2.0.0 release 