### PR TITLE
Address preg_match deprecation notice when sending null to second argument.

### DIFF
--- a/src/Handler/ContentRangeUploadHandler.php
+++ b/src/Handler/ContentRangeUploadHandler.php
@@ -67,7 +67,7 @@ class ContentRangeUploadHandler extends AbstractHandler
     {
         parent::__construct($request, $file, $config);
 
-        $contentRange = $this->request->header(self::CONTENT_RANGE_INDEX);
+        $contentRange = $this->request->header(self::CONTENT_RANGE_INDEX, '');
 
         $this->tryToParseContentRange($contentRange);
     }


### PR DESCRIPTION
When using `HandlerFactory::classFromRequest($request)`, this causes all handlers to check `canBeUsedForRequest`, thus newing up each handler. When we get to `ContentRangeUploadHandler`, the `$contentRange` would be `null` if we were not intending to use that handler for any case. Passing `null` as the subject to `preg_match` is deprecated.

Simple fix is to utilize the second argument for `header` and pass empty string as default.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | https://github.com/pionl/laravel-chunk-upload/issues/156