### PR TITLE
Symfony 8 compatibility

### DIFF
--- a/src/Handler/ChunksInRequestSimpleUploadHandler.php
+++ b/src/Handler/ChunksInRequestSimpleUploadHandler.php
@@ -37,6 +37,6 @@ class ChunksInRequestSimpleUploadHandler extends ChunksInRequestUploadHandler
     protected function getCurrentChunkFromRequest(Request $request)
     {
         // the chunk is indexed from 1 (for 5 chunks: 1,2,3,4,5)
-        return intval($request->get(static::KEY_CHUNK_NUMBER));
+        return intval($request->input(static::KEY_CHUNK_NUMBER));
     }
 }

--- a/src/Handler/ChunksInRequestUploadHandler.php
+++ b/src/Handler/ChunksInRequestUploadHandler.php
@@ -97,7 +97,7 @@ class ChunksInRequestUploadHandler extends AbstractHandler
     protected function getCurrentChunkFromRequest(Request $request)
     {
         // the chunk is indexed from zero (for 5 chunks: 0,1,2,3,4)
-        return intval($request->get(static::KEY_CHUNK_NUMBER)) + 1;
+        return intval($request->input(static::KEY_CHUNK_NUMBER)) + 1;
     }
 
     /**
@@ -109,7 +109,7 @@ class ChunksInRequestUploadHandler extends AbstractHandler
      */
     protected function getTotalChunksFromRequest(Request $request)
     {
-        return intval($request->get(static::KEY_ALL_CHUNKS));
+        return intval($request->input(static::KEY_ALL_CHUNKS));
     }
 
     /**

--- a/src/Handler/DropZoneUploadHandler.php
+++ b/src/Handler/DropZoneUploadHandler.php
@@ -35,7 +35,7 @@ class DropZoneUploadHandler extends ChunksInRequestUploadHandler
     public function __construct(Request $request, $file, $config)
     {
         parent::__construct($request, $file, $config);
-        $this->fileUuid = $request->get(self::CHUNK_UUID_INDEX);
+        $this->fileUuid = $request->input(self::CHUNK_UUID_INDEX);
     }
 
     /**
@@ -57,7 +57,7 @@ class DropZoneUploadHandler extends ChunksInRequestUploadHandler
      */
     protected function getCurrentChunkFromRequest(Request $request)
     {
-        return intval($request->get(self::CHUNK_INDEX, 0)) + 1;
+        return intval($request->input(self::CHUNK_INDEX, 0)) + 1;
     }
 
     /**
@@ -69,7 +69,7 @@ class DropZoneUploadHandler extends ChunksInRequestUploadHandler
      */
     protected function getTotalChunksFromRequest(Request $request)
     {
-        return intval($request->get(self::CHUNK_TOTAL_INDEX, 1));
+        return intval($request->input(self::CHUNK_TOTAL_INDEX, 1));
     }
 
     /**

--- a/src/Handler/NgFileUploadHandler.php
+++ b/src/Handler/NgFileUploadHandler.php
@@ -88,15 +88,15 @@ class NgFileUploadHandler extends ChunksInRequestUploadHandler
                      && ctype_digit($request->input(static::KEY_CHUNK_SIZE))
                      && ctype_digit($request->input(static::KEY_CHUNK_CURRENT_SIZE));
 
-        if ($request->get(static::KEY_CHUNK_SIZE) < $request->get(static::KEY_CHUNK_CURRENT_SIZE)) {
+        if ($request->input(static::KEY_CHUNK_SIZE) < $request->input(static::KEY_CHUNK_CURRENT_SIZE)) {
             throw new ChunkInvalidValueException();
         }
 
-        if ($request->get(static::KEY_CHUNK_NUMBER) < 0) {
+        if ($request->input(static::KEY_CHUNK_NUMBER) < 0) {
             throw new ChunkInvalidValueException();
         }
 
-        if ($request->get(static::KEY_TOTAL_SIZE) < 0) {
+        if ($request->input(static::KEY_TOTAL_SIZE) < 0) {
             throw new ChunkInvalidValueException();
         }
 
@@ -112,12 +112,12 @@ class NgFileUploadHandler extends ChunksInRequestUploadHandler
      */
     protected function getTotalChunksFromRequest(Request $request)
     {
-        if (!$request->get(static::KEY_CHUNK_SIZE)) {
+        if (!$request->input(static::KEY_CHUNK_SIZE)) {
             return 0;
         }
 
         return intval(
-            ceil($request->get(static::KEY_TOTAL_SIZE) / $request->get(static::KEY_CHUNK_SIZE))
+            ceil($request->input(static::KEY_TOTAL_SIZE) / $request->input(static::KEY_CHUNK_SIZE))
         );
     }
 }

--- a/src/Handler/ResumableJSUploadHandler.php
+++ b/src/Handler/ResumableJSUploadHandler.php
@@ -33,7 +33,7 @@ class ResumableJSUploadHandler extends ChunksInRequestUploadHandler
     {
         parent::__construct($request, $file, $config);
 
-        $this->fileUuid = $request->get(self::CHUNK_UUID_INDEX);
+        $this->fileUuid = $request->input(self::CHUNK_UUID_INDEX);
     }
 
     /**
@@ -55,7 +55,7 @@ class ResumableJSUploadHandler extends ChunksInRequestUploadHandler
      */
     protected function getCurrentChunkFromRequest(Request $request)
     {
-        return $request->get(self::CHUNK_NUMBER_INDEX);
+        return $request->input(self::CHUNK_NUMBER_INDEX);
     }
 
     /**
@@ -67,7 +67,7 @@ class ResumableJSUploadHandler extends ChunksInRequestUploadHandler
      */
     protected function getTotalChunksFromRequest(Request $request)
     {
-        return $request->get(self::TOTAL_CHUNKS_INDEX);
+        return $request->input(self::TOTAL_CHUNKS_INDEX);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

This package currently returns warnings: `Since symfony/http-foundation 7.4: Request::get() is deprecated, use properties ->attributes, query or request directly instead`. In Symfony version 8 (and probably Laravel version 13), `Request::get()` will be removed. Therefore, I replaced all `$request-get()` in the code with `$request->input()`.